### PR TITLE
Fix firebase studio port conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack -p 9002",
+    "dev": "sh -c 'next dev --turbopack -p ${PORT:-9002} --hostname 0.0.0.0'",
     "genkit:dev": "genkit start -- tsx src/ai/dev.ts",
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
     "build": "next build",


### PR DESCRIPTION
Update Next.js dev script to use `PORT` environment variable and bind to `0.0.0.0`.

This change resolves `EADDRINUSE` errors by allowing Firebase Studio to dynamically assign a port for the web server, instead of hardcoding port 9002, and ensures the server is accessible by binding to all network interfaces.

---
<a href="https://cursor.com/background-agent?bcId=bc-57088cf2-e7e6-45a1-97f9-35628549fa66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-57088cf2-e7e6-45a1-97f9-35628549fa66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

